### PR TITLE
Improve for codeception 5 and PHP 8.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .settings/
 vendor/
 tests/integration/tests/_log/
-tests/integration/tests/_helpers/
+tests/integration/tests/_helpers/*
+!tests/integration/tests/_helpers/WebGuy.php
 tests/integration/tests/_data/VisualCeption/SimpleCept.SimpleBlock.png

--- a/src/Codeception/Module/VisualCeption.php
+++ b/src/Codeception/Module/VisualCeption.php
@@ -495,7 +495,7 @@ class VisualCeption extends CodeceptionModule implements MultiSession
             $fullShot->writeImage($elementPath);
 
             if ($this->config["fullScreenShot"] !== true) {
-                $fullShot->cropImage($coords['width'], $coords['height'], $coords['offset_x'], $coords['offset_y']);
+                $fullShot->cropImage((int)$coords['width'], (int)$coords['height'], (int)$coords['offset_x'], (int)$coords['offset_y']);
             }
             $fullShot->writeImage($elementPath);
 
@@ -505,7 +505,7 @@ class VisualCeption extends CodeceptionModule implements MultiSession
             $screenshotBinary = $this->webDriver->takeScreenshot();
 
             $screenShotImage->readimageblob($screenshotBinary);
-            $screenShotImage->cropImage($coords['width'], $coords['height'], $coords['offset_x'], $coords['offset_y']);
+            $screenShotImage->cropImage((int)$coords['width'], (int)$coords['height'], (int)$coords['offset_x'], (int)$coords['offset_y']);
             $screenShotImage->writeImage($elementPath);
         }
 

--- a/tests/integration/tests/_helpers/WebGuy.php
+++ b/tests/integration/tests/_helpers/WebGuy.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * Inherited Methods
+ * @method void wantTo($text)
+ * @method void wantToTest($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method void pause($vars = [])
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class WebGuy extends \Codeception\Actor
+{
+    use _generated\WebGuyActions;
+
+    /**
+     * Define custom actions here
+     */
+
+    // multi session testing needs to be explicitly enabled since codeception 3, see https://codeception.com/04-24-2019/codeception-3.0.html
+    use \Codeception\Lib\Actor\Shared\Friend;
+}


### PR DESCRIPTION
Hi,

I found your Pull Request https://github.com/Codeception/VisualCeption/pull/78 and saw, the test in the pipeline has failed.

So I investigated and found, the multi session testing needs some additional configuration since codeception 3 https://codeception.com/04-24-2019/codeception-3.0.html This was not an issue until now, because the old pipeline used codeception 2.

And while I did the changes and tested with my own environment, I found another PHP 8.1 issue, where float number have been passed, but integers are required.

Would be great, if you could merge this and update your Pull Request.

Thank you.

 